### PR TITLE
Alltoall

### DIFF
--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -1,9 +1,9 @@
 source /etc/profile.d/nf_csh_modules
 module purge
-module load intel-fc/14.3.174
-module load intel-cc/14.3.174
-module load netcdf/4.3.2
+module load intel-fc/15.0.1.133
+module load intel-cc/15.0.1.133
+module load netcdf/4.3.3.1
 module load oasis/dev
-module load openmpi/1.8.4
+module load openmpi/1.8.4-debug
 setenv mpirunCommand   "mpirun --mca orte_base_help_aggregate 0 -np"
 setenv VALGRIND_MPI_WRAPPERS /home/599/nah599/usr/local/lib/valgrind/libmpiwrap-amd64-linux.so

--- a/bin/mkmf.template.nci
+++ b/bin/mkmf.template.nci
@@ -29,7 +29,7 @@ INCLUDE   = -I$(NETCDF_ROOT)/include \
 			-I$(OASIS_ROOT)/include/mct
 
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
-FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume buffered_io -convert big_endian
+FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume buffered_io -convert big_endian -grecord-gcc-switches -align all
 FFLAGS_OPT = -O3 -debug minimal -xHost
 FFLAGS_DEBUG = -g -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv
 FFLAGS_REPRO = -O2 -debug minimal -no-vec -fp-model precise

--- a/src/shared/mpp/include/mpp_alltoall_mpi.h
+++ b/src/shared/mpp/include/mpp_alltoall_mpi.h
@@ -1,7 +1,7 @@
 subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
 
-    MPP_TYPE_, dimension(:), intent(in) :: sbuf
-    MPP_TYPE_, dimension(:), intent(inout) :: rbuf
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
 
     integer, intent(in), optional :: pelist(0:)
     integer :: n
@@ -31,7 +31,7 @@ subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
     MPP_TYPE_, intent(in) :: sbuf(:)
     MPP_TYPE_, intent(inout) :: rbuf(:)
 
-    ! TODO: Optional displacements; set to cumulative sums of buf_msg_len
+    ! TODO: Optionally set displacements to cumulative sums of ssize, rsize
     integer, intent(in) :: ssize(:), rsize(:)
     integer, intent(in) :: sdispl(:), rdispl(:)
 

--- a/src/shared/mpp/include/mpp_alltoall_mpi.h
+++ b/src/shared/mpp/include/mpp_alltoall_mpi.h
@@ -16,6 +16,7 @@ subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
 
     if (verbose) call mpp_error(NOTE, 'MPP_ALLTOALL_: using MPI_Alltoall...')
 
+    ! TODO: Message lengths greater than 1
     call MPI_Alltoall(sbuf, 1, MPI_TYPE_, rbuf, 1, MPI_TYPE_, &
                       peset(n)%id, error)
 
@@ -23,3 +24,35 @@ subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
         call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
 
 end subroutine MPP_ALLTOALL_
+
+
+subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
+
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
+
+    ! TODO: Optional displacements; set to cumulative sums of buf_msg_len
+    integer, intent(in) :: ssize(:), rsize(:)
+    integer, intent(in) :: sdispl(:), rdispl(:)
+
+    integer, intent(in), optional :: pelist(0:)
+    integer :: n
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
+
+    n = get_peset(pelist)
+    if (peset(n)%count .eq. 1) return
+
+    if (current_clock .NE. 0) call SYSTEM_CLOCK(start_tick)
+
+    if (verbose) call mpp_error(NOTE, 'MPP_ALLTOALL_: using MPI_Alltoallv...')
+
+    call MPI_Alltoallv(sbuf, ssize, sdispl, MPI_TYPE_, &
+                       rbuf, rsize, rdispl, MPI_TYPE_, &
+                       peset(n)%id, error)
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_ALLTOALLV_

--- a/src/shared/mpp/include/mpp_alltoall_mpi.h
+++ b/src/shared/mpp/include/mpp_alltoall_mpi.h
@@ -1,0 +1,25 @@
+subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
+
+    MPP_TYPE_, dimension(:), intent(in) :: sbuf
+    MPP_TYPE_, dimension(:), intent(inout) :: rbuf
+
+    integer, intent(in), optional :: pelist(0:)
+    integer :: n
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
+
+    n = get_peset(pelist)
+    if (peset(n)%count .eq. 1) return
+
+    if (current_clock .NE. 0) call SYSTEM_CLOCK(start_tick)
+
+    if (verbose) call mpp_error(NOTE, 'MPP_ALLTOALL_: using MPI_Alltoall...')
+
+    call MPI_Alltoall(sbuf, 1, MPI_TYPE_, rbuf, 1, MPI_TYPE_, &
+                      peset(n)%id, error)
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_ALLTOALL_

--- a/src/shared/mpp/include/mpp_alltoall_nocomm.h
+++ b/src/shared/mpp/include/mpp_alltoall_nocomm.h
@@ -4,10 +4,38 @@ subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
     MPP_TYPE_, dimension(:), intent(inout) :: rbuf
 
     integer, intent(in), optional :: pelist(0:)
-    integer :: n
 
     if (.NOT. module_is_initialized) &
         call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
 
-    return
+    if (current_clock .NE. 0) call SYSTEM_CLOCK(start_tick)
+
+    rbuf(:) = sbuf(:)
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
+
 end subroutine MPP_ALLTOALL_
+
+
+subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
+
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
+
+    integer, intent(in) :: ssize(:), rsize(:)
+    integer, intent(in) :: sdispl(:), rdispl(:)
+
+    integer, intent(in), optional :: pelist(0:)
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
+
+    if (current_clock .NE. 0) call SYSTEM_CLOCK(start_tick)
+
+    rbuf(:) = sbuf(:)
+
+    if (current_clock .NE. 0) &
+        call increment_current_clock(EVENT_ALLTOALL, MPP_TYPE_BYTELEN_)
+
+end subroutine MPP_ALLTOALLV_

--- a/src/shared/mpp/include/mpp_alltoall_nocomm.h
+++ b/src/shared/mpp/include/mpp_alltoall_nocomm.h
@@ -1,0 +1,13 @@
+subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
+
+    MPP_TYPE_, dimension(:), intent(in) :: sbuf
+    MPP_TYPE_, dimension(:), intent(inout) :: rbuf
+
+    integer, intent(in), optional :: pelist(0:)
+    integer :: n
+
+    if (.NOT. module_is_initialized) &
+        call mpp_error(FATAL, 'MPP_ALLTOALL: You must first call mpp_init.')
+
+    return
+end subroutine MPP_ALLTOALL_

--- a/src/shared/mpp/include/mpp_alltoall_sma.h
+++ b/src/shared/mpp/include/mpp_alltoall_sma.h
@@ -4,9 +4,22 @@ subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
     MPP_TYPE_, dimension(:), intent(inout) :: rbuf
 
     integer, intent(in), optional :: pelist(0:)
-    integer :: n
 
     call mpp_error(FATAL, 'MPP_ALLTOALL: No SHMEM implementation.')
 
-    return
 end subroutine MPP_ALLTOALL_
+
+
+subroutine MPP_ALLTOALLV_(sbuf, ssize, sdispl, rbuf, rsize, rdispl, pelist)
+
+    MPP_TYPE_, intent(in) :: sbuf(:)
+    MPP_TYPE_, intent(inout) :: rbuf(:)
+
+    integer, intent(in) :: ssize(:), rsize(:)
+    integer, intent(in) :: sdispl(:), rdispl(:)
+
+    integer, intent(in), optional :: pelist(0:)
+
+    call mpp_error(FATAL, 'MPP_ALLTOALLV: No SHMEM implementation.')
+
+end subroutine MPP_ALLTOALLV_

--- a/src/shared/mpp/include/mpp_alltoall_sma.h
+++ b/src/shared/mpp/include/mpp_alltoall_sma.h
@@ -1,0 +1,12 @@
+subroutine MPP_ALLTOALL_(sbuf, rbuf, pelist)
+
+    MPP_TYPE_, dimension(:), intent(in) :: sbuf
+    MPP_TYPE_, dimension(:), intent(inout) :: rbuf
+
+    integer, intent(in), optional :: pelist(0:)
+    integer :: n
+
+    call mpp_error(FATAL, 'MPP_ALLTOALL: No SHMEM implementation.')
+
+    return
+end subroutine MPP_ALLTOALL_

--- a/src/shared/mpp/include/mpp_comm_mpi.inc
+++ b/src/shared/mpp/include/mpp_comm_mpi.inc
@@ -1098,3 +1098,19 @@ end subroutine mpp_gsm_free
 #undef MPP_TYPE_BYTELEN_
 #define MPP_TYPE_BYTELEN_ 4
 #include <mpp_sum_mpi.h>
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            SCATTER AND GATHER ROUTINES: mpp_alltoall                        !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_alltoall_mpi.h>

--- a/src/shared/mpp/include/mpp_comm_mpi.inc
+++ b/src/shared/mpp/include/mpp_comm_mpi.inc
@@ -1106,40 +1106,48 @@ end subroutine mpp_gsm_free
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_ALLTOALLV_ mpp_alltoall_int4_v
 #define MPP_TYPE_ integer(INT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_alltoall_mpi.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_ALLTOALLV_ mpp_alltoall_int8_v
 #define MPP_TYPE_ integer(LONG_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_INTEGER8
 #include <mpp_alltoall_mpi.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_ALLTOALLV_ mpp_alltoall_real4_v
 #define MPP_TYPE_ real(FLOAT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_REAL4
 #include <mpp_alltoall_mpi.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_ALLTOALLV_ mpp_alltoall_real8_v
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8

--- a/src/shared/mpp/include/mpp_comm_mpi.inc
+++ b/src/shared/mpp/include/mpp_comm_mpi.inc
@@ -1114,3 +1114,33 @@ end subroutine mpp_gsm_free
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_alltoall_mpi.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_alltoall_mpi.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_alltoall_mpi.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_alltoall_mpi.h>

--- a/src/shared/mpp/include/mpp_comm_nocomm.inc
+++ b/src/shared/mpp/include/mpp_comm_nocomm.inc
@@ -958,3 +958,49 @@ end subroutine mpp_exit
 #undef MPP_TYPE_BYTELEN_
 #define MPP_TYPE_BYTELEN_ 4
 #include <mpp_sum_nocomm.h>
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            SCATTER AND GATHER ROUTINES: mpp_alltoall                        !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_alltoall_nocomm.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_alltoall_nocomm.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_alltoall_nocomm.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_alltoall_nocomm.h>

--- a/src/shared/mpp/include/mpp_comm_nocomm.inc
+++ b/src/shared/mpp/include/mpp_comm_nocomm.inc
@@ -966,40 +966,48 @@ end subroutine mpp_exit
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_ALLTOALLV_ mpp_alltoall_int4_v
 #define MPP_TYPE_ integer(INT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_alltoall_nocomm.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_ALLTOALLV_ mpp_alltoall_int8_v
 #define MPP_TYPE_ integer(LONG_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_INTEGER8
 #include <mpp_alltoall_nocomm.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_ALLTOALLV_ mpp_alltoall_real4_v
 #define MPP_TYPE_ real(FLOAT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_REAL4
 #include <mpp_alltoall_nocomm.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_ALLTOALLV_ mpp_alltoall_real8_v
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8

--- a/src/shared/mpp/include/mpp_comm_sma.inc
+++ b/src/shared/mpp/include/mpp_comm_sma.inc
@@ -1066,6 +1066,52 @@ end subroutine mpp_malloc
 #define MPP_TYPE_BYTELEN_ 4
 #include <mpp_sum_sma.h>
 
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                             !
+!            SCATTER AND GATHER ROUTINES: mpp_alltoall                        !
+!                                                                             !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_TYPE_ integer(INT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_INTEGER4
+#include <mpp_alltoall_sma.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_TYPE_ integer(LONG_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_INTEGER8
+#include <mpp_alltoall_sma.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_TYPE_ real(FLOAT_KIND)
+#define MPP_TYPE_BYTELEN_ 4
+#define MPI_TYPE_ MPI_REAL4
+#include <mpp_alltoall_sma.h>
+
+#undef MPP_ALLTOALL_
+#undef MPP_TYPE_
+#undef MPP_TYPE_BYTELEN_
+#undef MPI_TYPE_
+#define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_TYPE_ real(DOUBLE_KIND)
+#define MPP_TYPE_BYTELEN_ 8
+#define MPI_TYPE_ MPI_REAL8
+#include <mpp_alltoall_sma.h>
+
 !#######################################################################
 !these local versions are written for grouping into shmem_integer_wait
 subroutine shmem_int4_wait_local( ivar, cmp_value )

--- a/src/shared/mpp/include/mpp_comm_sma.inc
+++ b/src/shared/mpp/include/mpp_comm_sma.inc
@@ -1073,40 +1073,48 @@ end subroutine mpp_malloc
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int4
+#define MPP_ALLTOALLV_ mpp_alltoall_int4_v
 #define MPP_TYPE_ integer(INT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_alltoall_sma.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_int8
+#define MPP_ALLTOALLV_ mpp_alltoall_int8_v
 #define MPP_TYPE_ integer(LONG_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_INTEGER8
 #include <mpp_alltoall_sma.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real4
+#define MPP_ALLTOALLV_ mpp_alltoall_real4_v
 #define MPP_TYPE_ real(FLOAT_KIND)
 #define MPP_TYPE_BYTELEN_ 4
 #define MPI_TYPE_ MPI_REAL4
 #include <mpp_alltoall_sma.h>
 
 #undef MPP_ALLTOALL_
+#undef MPP_ALLTOALLV_
 #undef MPP_TYPE_
 #undef MPP_TYPE_BYTELEN_
 #undef MPI_TYPE_
 #define MPP_ALLTOALL_ mpp_alltoall_real8
+#define MPP_ALLTOALLV_ mpp_alltoall_real8_v
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #define MPP_TYPE_BYTELEN_ 8
 #define MPI_TYPE_ MPI_REAL8

--- a/src/shared/mpp/mpp.F90
+++ b/src/shared/mpp/mpp.F90
@@ -675,7 +675,9 @@ private
   ! </interface>
   interface mpp_alltoall
      module procedure mpp_alltoall_int4
-     ! TODO: Other types, multidimensions, etc?
+     module procedure mpp_alltoall_int8
+     module procedure mpp_alltoall_real4
+     module procedure mpp_alltoall_real8
   end interface
 
   !#####################################################################

--- a/src/shared/mpp/mpp.F90
+++ b/src/shared/mpp/mpp.F90
@@ -164,6 +164,7 @@ module mpp_mod
   use mpp_parameter_mod, only : MAX_EVENTS, MAX_BINS, MAX_EVENT_TYPES, MAX_CLOCKS
   use mpp_parameter_mod, only : MAXPES, EVENT_WAIT, EVENT_ALLREDUCE, EVENT_BROADCAST
   use mpp_parameter_mod, only : EVENT_RECV, EVENT_SEND, MPP_READY, MPP_WAIT
+  use mpp_parameter_mod, only : EVENT_ALLTOALL
   use mpp_parameter_mod, only : mpp_parameter_version=>version, mpp_parameter_tagname=>tagname
   use mpp_parameter_mod, only : DEFAULT_TAG
   use mpp_parameter_mod, only : COMM_TAG_1,  COMM_TAG_2,  COMM_TAG_3,  COMM_TAG_4
@@ -216,6 +217,7 @@ private
   public :: mpp_chksum, mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv
   public :: mpp_broadcast, mpp_malloc, mpp_init, mpp_exit
   public :: mpp_gather
+  public :: mpp_alltoall
 #ifdef use_MPI_GSM
   public :: mpp_gsm_malloc, mpp_gsm_free
 #endif
@@ -663,6 +665,18 @@ private
      module procedure mpp_gather_real8_1dv
   end interface
 
+
+  !#####################################################################
+  ! <interface name="mpp_alltoall">
+  !   <overview>
+  !     scatter a vector across all PEs
+  !     (e.g. transpose the vector and PE index)
+  !   </overview>
+  ! </interface>
+  interface mpp_alltoall
+     module procedure mpp_alltoall_int4
+     ! TODO: Other types, multidimensions, etc?
+  end interface
 
   !#####################################################################
 

--- a/src/shared/mpp/mpp.F90
+++ b/src/shared/mpp/mpp.F90
@@ -678,6 +678,10 @@ private
      module procedure mpp_alltoall_int8
      module procedure mpp_alltoall_real4
      module procedure mpp_alltoall_real8
+     module procedure mpp_alltoall_int4_v
+     module procedure mpp_alltoall_int8_v
+     module procedure mpp_alltoall_real4_v
+     module procedure mpp_alltoall_real8_v
   end interface
 
   !#####################################################################

--- a/src/shared/mpp/mpp_parameter.F90
+++ b/src/shared/mpp/mpp_parameter.F90
@@ -16,6 +16,7 @@ module mpp_parameter_mod
   public :: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE_DRIVER
   public :: CLOCK_MODULE, CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA, MAX_BINS
   public :: EVENT_ALLREDUCE, EVENT_BROADCAST, EVENT_RECV, EVENT_SEND, EVENT_WAIT
+  public :: EVENT_ALLTOALL
   public :: DEFAULT_TAG
   public :: COMM_TAG_1,  COMM_TAG_2,  COMM_TAG_3,  COMM_TAG_4
   public :: COMM_TAG_5,  COMM_TAG_6,  COMM_TAG_7,  COMM_TAG_8
@@ -50,6 +51,7 @@ module mpp_parameter_mod
   integer, parameter :: NOTE=0, WARNING=1, FATAL=2
   integer, parameter :: MAX_CLOCKS=400, MAX_EVENT_TYPES=5, MAX_EVENTS=40000
   integer, parameter :: EVENT_ALLREDUCE=1, EVENT_BROADCAST=2, EVENT_RECV=3, EVENT_SEND=4, EVENT_WAIT=5
+  integer, parameter :: EVENT_ALLTOALL=6
   integer, parameter :: MPP_CLOCK_SYNC=1, MPP_CLOCK_DETAILED=2
   integer            :: DEFAULT_TAG = 1
   !--- predefined clock granularities, but you can use any integer


### PR DESCRIPTION
This patch does the following:
- Adds a new `mpp_alltoall` to FMS which wraps `MPI_Alltoall` for the MPI implementation. Single cpu and SHMEM implementations are not supported
- A `do_alltoall` flag is added to `xgrid_nml`
- The `nsend` and `nrecv` message passing within `xgrid.F90` is replaced with two `mpp_alltoall` calls when `do_alltoall` is enabled. 