### PR TITLE
Removed redundant mpp_max() collectives in land cell checks

### DIFF
--- a/src/mom5/ocean_diag/ocean_tracer_diag.F90
+++ b/src/mom5/ocean_diag/ocean_tracer_diag.F90
@@ -2722,7 +2722,6 @@ subroutine tracer_land_cell_check (Time, T_prog)
      enddo
   enddo
 
-  call mpp_max(num)
   if (num > 0) call mpp_error(FATAL)
 
 9100  format(/' " =>Error: Land cell at (i,j,k) = ','(',i4,',',i4,',',i4,'),',&

--- a/src/mom5/ocean_diag/ocean_velocity_diag.F90
+++ b/src/mom5/ocean_diag/ocean_velocity_diag.F90
@@ -925,7 +925,6 @@ subroutine velocity_land_cell_check(Time, Velocity)
 
   endif 
 
-  call mpp_max(num)
   if (num > 0)  then 
      call mpp_error(FATAL,'==>Error: found nonzero ocean velocity over land points. ')
   endif 


### PR DESCRIPTION
Currently, the tracer and velocity land cell checks calculate the number of local land cell violations (`num`), do an `mpp_max` to get the total number, and raise `mpp_error` if this numberis nonzero.

It should not be necessary to do the `mpp_max`. If any PE detects a nonzero `num`, then it can locally raise `mpp_error`, which will terminate the job.

This will have a very marginal performance improvement, but the main reason is that we have seen the occasional model hang inside these calls. If they are not necessary, then it would be good to remove them.