### PR TITLE
SIS axis construction

### DIFF
--- a/src/ice_sis/ice_grid.F90
+++ b/src/ice_sis/ice_grid.F90
@@ -296,6 +296,7 @@ contains
     integer, dimension(2)               :: tile1, tile2
     integer, dimension(2)               :: istart1, iend1, jstart1, jend1
     integer, dimension(2)               :: istart2, iend2, jstart2, jend2
+    integer, dimension(4)               :: start, nread
     character(len=80)                   :: domainname
     character(len=128)                  :: grid_file, ocean_topog
     character(len=256)                  :: ocean_hgrid, ocean_mosaic, attvalue
@@ -310,11 +311,6 @@ contains
     integer                             :: npes, p
     logical                             :: symmetrize, ndivx_is_even, im_is_even
 
-    ! Grid testing
-    logical :: mosaic_axes
-    integer, dimension(4) :: start, nread
-
-    mosaic_axes = .true.
 
     grid_file = 'INPUT/grid_spec.nc'
     ocean_topog = 'INPUT/topog.nc'
@@ -569,25 +565,31 @@ contains
        xb1d = sum(tmpx,2)/(jm+1)
        yb1d = sum(tmpy,1)/(im+1)
        deallocate(tmpx, tmpy)
-    else if (mosaic_axes .and. grid_version == VERSION_2) then
 
+    else if (grid_version == VERSION_2) then
        allocate(tmpx(2*im + 1, 2), tmpy(2, 2*jm + 1))
 
+       ! Default index span initialization
        start(:) = 1; nread(:) = 1
- 
+
+       ! Read x-axis along y[0]
        start(1) = 1; nread(1) = 2*im + 1
        start(2) = 2; nread(2) = 2
        call read_data(ocean_hgrid, 'x', tmpx, start, nread, no_domain=.true.)
        xb1d(:) = tmpx(::2, 1)
 
-       ! Start at (im / 4) to ensure that dy is constant through the tripole
+       ! Read y-axis along x[im/4]
+       ! NOTE: At x[im/4], dy is constant for a standard global tripole grid
        start(1) = 2*(im/4) + 1; nread(1) = 2
        start(2) = 1; nread(2) = 2*jm + 1
        call read_data(ocean_hgrid, 'y', tmpy, start, nread, no_domain=.true.)
        yb1d(:) = tmpy(1, ::2)
 
        deallocate(tmpx, tmpy)
+
     else
+       ! For non-mosaic grids, calculate the mean axis values across the grid
+
        allocate ( tmpx(isc:iec+1, jm+1) )
        call mpp_set_domain_symmetry(Domain, .TRUE.)
        call mpp_global_field(Domain, geo_lonv, tmpx, flags=YUPDATE, position=CORNER)


### PR DESCRIPTION
This patch alters the way that the `xb` and `yb` axes are calculated in SIS.

Previously, the axes were calculated by averaging across the entire grid to produce mean values of `x` and `y` using `mpp_global_field`. This version reads the `ocean_hgrid.nc` file (when mosaic, or "version 2", grids are enabled), as in the MOM source.

This change was required to enable SIS to scale beyond 10,000 CPUs. Previously, such experiments would fail inside the `mpp_global_field` calls.

When mosaic grids are not enabled, the old `mpp_global_field` function is used.

This changes the values of `xb` and `yb` but is now more consistent with the MOM source.