### PR TITLE
Cleaned up nci environs so it compiles cleanly.

### DIFF
--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -6,4 +6,4 @@ module load netcdf/4.3.3.1
 module load oasis/dev
 module load openmpi/1.8.4
 setenv mpirunCommand   "mpirun --mca orte_base_help_aggregate 0 -np"
-setenv VALGRIND_MPI_WRAPPERS /home/599/nah599/more_home/usr/local/lib/valgrind/libmpiwrap-amd64-linux.so
+set cppDefs  = ( "-Duse_netCDF -Duse_libMPI -DUSE_OCEAN_BGC -DENABLE_ODA -DSPMD -DLAND_BND_TRACERS" )

--- a/bin/mkmf.template.nci
+++ b/bin/mkmf.template.nci
@@ -20,13 +20,17 @@ CC = mpicc
 REPRO =
 VERBOSE =
 OPT = on
+OASIS = 
 
 MAKEFLAGS += --jobs=4
 
-INCLUDE   = -I$(NETCDF_ROOT)/include \
-			-I$(OASIS_ROOT)/include/psmile.MPI1 \
+INCLUDE   = -I$(NETCDF_ROOT)/include 
+
+ifneq ($(OASIS),)
+INCLUDE  += -I$(OASIS_ROOT)/include/psmile.MPI1 \
 			-I$(OASIS_ROOT)/include/pio \
 			-I$(OASIS_ROOT)/include/mct
+endif                
 
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
 FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all
@@ -62,7 +66,10 @@ LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
 LIBS := -L$(NETCDF_ROOT)/lib -lnetcdf -lnetcdff \
-		-L$(OASIS_ROOT)/lib -lpsmile.MPI1 -lmct -lmpeu -lscrip \
+
+ifneq ($(OASIS),)
+LIBS += -L$(OASIS_ROOT)/lib -lpsmile.MPI1 -lmct -lmpeu -lscrip
+endif
 
 LDFLAGS += $(LIBS)
 


### PR DESCRIPTION
Vanilla config clone to NCI didn't compile cleanly due to dependency on OASIS libs in /projects/v45.

Moved OASIS dependency under pre-processor directive. Made netcdf4 default for nci.

