### PR TITLE
Disable user .gitconfig in FMS_compile.csh

### DIFF
--- a/exp/FMS_compile.csh
+++ b/exp/FMS_compile.csh
@@ -104,7 +104,13 @@ set lib_name = "lib_FMS"
 # The version of an executable can be found with the following command:
 # readelf -p .rodata <executable> | grep -A 1 'version.F90'
 setenv GIT_CONFIG_NOGLOBAL 'yes'
-sed -e "s/{MOM_VERSION}/`git rev-parse HEAD`/g" $code_dir/shared/version/version.F90.template > $code_dir/shared/version/version.F90
+
+set old_hash=`grep 'MOM_VERSION' ../src/shared/version/version.F90 | cut -d '"' -f 2 | cut -d '=' -f 2`
+set new_hash=`git rev-parse HEAD`
+
+if ( $old_hash != $new_hash ) then
+    sed -e "s/{MOM_VERSION}/$new_hash/g" $code_dir/shared/version/version.F90.template > $code_dir/shared/version/version.F90
+endif
 
 mkdir -p $executable:h:h/$lib_name
 cd $executable:h:h/$lib_name

--- a/exp/FMS_compile.csh
+++ b/exp/FMS_compile.csh
@@ -103,6 +103,7 @@ set lib_name = "lib_FMS"
 # The version string is the git hash of the commit used to build the code.
 # The version of an executable can be found with the following command:
 # readelf -p .rodata <executable> | grep -A 1 'version.F90'
+setenv GIT_CONFIG_NOGLOBAL 'yes'
 sed -e "s/{MOM_VERSION}/`git rev-parse HEAD`/g" $code_dir/shared/version/version.F90.template > $code_dir/shared/version/version.F90
 
 mkdir -p $executable:h:h/$lib_name


### PR DESCRIPTION
FMS_compile.csh uses git to construct a version string, but the version
used by the script (due to `module purge`) may not match the user's git
version if they use a private module.

This disables the user's .gitconfig and uses system defaults.