### PR TITLE
Fix octal representation

### DIFF
--- a/test/model_test_setup.py
+++ b/test/model_test_setup.py
@@ -141,7 +141,7 @@ class ModelTestSetup(object):
         frun, run_file = tempfile.mkstemp(dir=self.exp_dir)
         os.write(frun, run_script)
         os.close(frun)
-        os.chmod(run_file, 0755)
+        os.chmod(run_file, 0o755)
 
         # Submit the experiment. This will block until it has finished.
         if qsub:


### PR DESCRIPTION
Octal numbers should be represented '0oddd', as per PEP3127