### PR TITLE
Made openmpi 1.10.2 default for NCI build. 

### DIFF
--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -5,5 +5,5 @@ module load intel-cc/16.0.2.181
 module load netcdf/4.3.3.1
 module use /projects/v45/modules
 module load oasis/dev
-module load openmpi/1.8.4
+module load openmpi/1.10.2
 setenv mpirunCommand   "mpirun --mca orte_base_help_aggregate 0 -np"


### PR DESCRIPTION
This fixed segfaults, primarily associated with calls to MPI_Finalize, that occurred spontaneously after a system downtime at the beginning of 2017