### PR TITLE
ACCESS bugfix: ROOT_GLOBAL -> GLOBAL_ROOT_ONLY

### DIFF
--- a/src/access_coupler/mom_oasis3_interface.F90
+++ b/src/access_coupler/mom_oasis3_interface.F90
@@ -89,7 +89,7 @@ use mpp_domains_mod, only: mpp_get_compute_domain, &
                            mpp_get_data_domain, &
                            mpp_get_global_domain, &
                            mpp_global_field
-use mpp_parameter_mod, only: ROOT_GLOBAL
+use mpp_parameter_mod, only: GLOBAL_ROOT_ONLY
 use ocean_types_mod, only: ice_ocean_boundary_type, &
                            ocean_public_type, &
                            ocean_domain_type
@@ -791,10 +791,10 @@ if ( write_restart ) then
 
         if (parallel_coupling) then
           call mpp_global_field(Ocean_sfc%domain, vtmp(iisc:iiec,jjsc:jjec), &
-                                gtmp, flags=ROOT_GLOBAL)
+                                gtmp, flags=GLOBAL_ROOT_ONLY)
         else
           call mpp_global_field(Ocean_sfc%domain, vtmp(iisc:iiec,jjsc:jjec), &
-                                vwork, flags=ROOT_GLOBAL)
+                                vwork, flags=GLOBAL_ROOT_ONLY)
         end if
 
         if (mpp_pe() == mpp_root_pe()) then


### PR DESCRIPTION
The `mpp_global_field` calls in `write_coupler_restart` were incorrectly
using `ROOT_GLOBAL` as an input flag, which identifies the bit field,
rather than `GLOBAL_ROOT_ONLY`, which has the correct bit field enabled.

This patch correctly uses `GLOBAL_ROOT_ONLY` as the `flags` argument.

Thanks to Aidan Heerdegen for identifying this bug and Russ Fiedler for
identifying the problem and recommending the correct flag.