### PR TITLE
ACCESS-CM: mpp_global_field bugfix

### DIFF
--- a/src/access_coupler/mom_oasis3_interface.F90
+++ b/src/access_coupler/mom_oasis3_interface.F90
@@ -89,7 +89,7 @@ use mpp_domains_mod, only: mpp_get_compute_domain, &
                            mpp_get_data_domain, &
                            mpp_get_global_domain, &
                            mpp_global_field
-use mpp_parameter_mod, only: GLOBAL_ROOT_ONLY
+use mpp_parameter_mod, only: GLOBAL_ROOT_ONLY, XUPDATE, YUPDATE
 use ocean_types_mod, only: ice_ocean_boundary_type, &
                            ocean_public_type, &
                            ocean_domain_type
@@ -791,10 +791,10 @@ if ( write_restart ) then
 
         if (parallel_coupling) then
           call mpp_global_field(Ocean_sfc%domain, vtmp(iisc:iiec,jjsc:jjec), &
-                                gtmp, flags=GLOBAL_ROOT_ONLY)
+                                gtmp, flags=GLOBAL_ROOT_ONLY+XUPDATE+YUPDATE)
         else
           call mpp_global_field(Ocean_sfc%domain, vtmp(iisc:iiec,jjsc:jjec), &
-                                vwork, flags=GLOBAL_ROOT_ONLY)
+                                vwork, flags=GLOBAL_ROOT_ONLY+XUPDATE+YUPDATE)
         end if
 
         if (mpp_pe() == mpp_root_pe()) then


### PR DESCRIPTION
This patch adds the XUPDATE and YUPDATE flags to the mpp_global_field
calls for the OASIS restart file writes.  The previous version worked
without any problems, but raised warnings because these flags were not
present.  This patch removes those warnings.